### PR TITLE
Add compatibility for Debian 11

### DIFF
--- a/DEBIAN/postinst
+++ b/DEBIAN/postinst
@@ -9,11 +9,20 @@ if [ ${release} == "ubuntu" ]; then
 fi
 
 if [ ${release} == "debian" ]; then
-  rm /etc/udev/rules.d/53-c2-network-interfaces.rules.ubuntu
-  rm /etc/udev/rules.d/75-persistent-net-generator.rules.ubuntu
-  rm /lib/udev/trigger-interface
-  mv /etc/udev/rules.d/53-c2-network-interfaces.rules.debian /etc/udev/rules.d/53-c2-network-interfaces.rules
-  mv /etc/udev/rules.d/75-persistent-net-generator.rules.debian /etc/udev/rules.d/75-persistent-net-generator.rules
+  version=$(grep -oP "VERSION_ID=.\\K[0-9]+" /etc/os-release)
+  if [ ${debian_version} -lt 11 ]; then
+    rm /etc/udev/rules.d/53-c2-network-interfaces.rules.ubuntu
+    rm /etc/udev/rules.d/75-persistent-net-generator.rules.ubuntu
+    rm /lib/udev/trigger-interface
+    mv /etc/udev/rules.d/53-c2-network-interfaces.rules.debian /etc/udev/rules.d/53-c2-network-interfaces.rules
+    mv /etc/udev/rules.d/75-persistent-net-generator.rules.debian /etc/udev/rules.d/75-persistent-net-generator.rules
+  else
+    # used ubuntu rules for debian because in version 11 interfaces was renamed from eth to ens
+    rm /etc/udev/rules.d/53-c2-network-interfaces.rules.debian
+    rm /etc/udev/rules.d/75-persistent-net-generator.rules.debian
+    mv /etc/udev/rules.d/53-c2-network-interfaces.rules.ubuntu /etc/udev/rules.d/53-c2-network-interfaces.rules
+    mv /etc/udev/rules.d/75-persistent-net-generator.rules.ubuntu /etc/udev/rules.d/75-persistent-net-generator.rules
+  fi
 fi
 
 systemctl enable ec2net-scan.service

--- a/ec2ifscan
+++ b/ec2ifscan
@@ -11,22 +11,26 @@ fi
 
 # Validate os-release
 release=$(grep -P '^\ID=' /etc/os-release | tr -d 'ID=')
-version=$(grep -oP "VERSION_ID=.\\K[0-9]+\\.[0-9]+" /etc/os-release | tr -d ".")
 if [ ${release} == "ubuntu" ]; then
-  if [ ${version} -lt 1804 ]; then
+  ubuntu_version=$(grep -oP "VERSION_ID=.\\K[0-9]+\\.[0-9]+" /etc/os-release | tr -d ".")
+  if [ ${ubuntu_version} -lt 1804 ]; then
     echo "c2-ec2-netutils is not supported ubuntu version less than 18.04"
     exit 1
   fi
+  int_name="ens"
+  cfg_path="/etc/netplan"
+  extension=".yaml"
 fi
 
-if [ ${release} == "ubuntu" ]; then
-    int_name="ens"
-    cfg_path="/etc/netplan"
-    extension=".yaml"
-  else
+if [ ${release} == "debian" ]; then
+  debian_version=$(grep -oP "VERSION_ID=.\\K[0-9]+" /etc/os-release)
+  if [ ${debian_version} -lt 11 ]; then
     int_name="eth"
-    cfg_path="/etc/network/interfaces.d"
-    extension=".cfg"
+  else
+    int_name="ens"
+  fi
+  cfg_path="/etc/network/interfaces.d"
+  extension=".cfg"
 fi
 
 logger --tag ec2net "[ec2ifscan] Scanning for unconfigured interfaces"


### PR DESCRIPTION
Add compatibility for the Debian 11 where was renamed the interfaces from eth to ens.