### PR TITLE
Fix `grep -P` regexes to match PCRE2 syntax (debian-c2-ec2-netutils)

### DIFF
--- a/DEBIAN/changelog
+++ b/DEBIAN/changelog
@@ -1,3 +1,9 @@
+c2-ec2-netutils (1.1-4) stable; urgency=medium
+
+* Fix grep -P regexes to match PCRE2 syntax.
+
+-- Georgy Melnikov <gmelnikov@croc.ru> Mon, 22 May 2023 17:00:00 +0300
+
 c2-ec2-netutils (1.1-3) stable; urgency=medium
 
 * Fix routes and route-policy rules for Debian-like distros.

--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: c2-ec2-netutils
-Version: 1.1-3
+Version: 1.1-4
 Section: utils
 Architecture: all
 Maintainer: Evgeny Kovalev <evgkovalev@croc.ru>

--- a/DEBIAN/postinst
+++ b/DEBIAN/postinst
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-release=$(grep -P '^\ID=' /etc/os-release | tr -d 'ID=')
+release=$(grep -P '^ID=' /etc/os-release | tr -d 'ID=')
 if [ ${release} == "ubuntu" ]; then
   rm /etc/udev/rules.d/53-c2-network-interfaces.rules.debian
   rm /etc/udev/rules.d/75-persistent-net-generator.rules.debian

--- a/ec2ifdown
+++ b/ec2ifdown
@@ -17,7 +17,7 @@ if [ $UID -ne 0 ]; then
 fi
 
 # Validate os-release
-release=$(grep -P '^\ID=' /etc/os-release | tr -d 'ID=')
+release=$(grep -P '^ID=' /etc/os-release | tr -d 'ID=')
 version=$(grep -oP "VERSION_ID=.\\K[0-9]+\\.[0-9]+" /etc/os-release | tr -d ".")
 if [ ${release} == "ubuntu" ]; then
   if [ ${version} -lt 1804 ]; then

--- a/ec2ifscan
+++ b/ec2ifscan
@@ -10,7 +10,7 @@ if [ $UID -ne 0 ]; then
 fi
 
 # Validate os-release
-release=$(grep -P '^\ID=' /etc/os-release | tr -d 'ID=')
+release=$(grep -P '^ID=' /etc/os-release | tr -d 'ID=')
 if [ ${release} == "ubuntu" ]; then
   ubuntu_version=$(grep -oP "VERSION_ID=.\\K[0-9]+\\.[0-9]+" /etc/os-release | tr -d ".")
   if [ ${ubuntu_version} -lt 1804 ]; then

--- a/ec2ifup
+++ b/ec2ifup
@@ -17,7 +17,7 @@ if [ $UID -ne 0 ]; then
 fi
 
 # Validate os-release
-release=$(grep -P '^\ID=' /etc/os-release | tr -d 'ID=')
+release=$(grep -P '^ID=' /etc/os-release | tr -d 'ID=')
 version=$(grep -oP "VERSION_ID=.\\K[0-9]+\\.[0-9]+" /etc/os-release | tr -d ".")
 if [ ${release} == "ubuntu" ]; then
   if [ ${version} -lt 1804 ]; then

--- a/ec2net-functions
+++ b/ec2net-functions
@@ -24,7 +24,7 @@ fi
 export HWADDR
 
 RULES_FILE="/etc/udev/rules.d/69-c2-persistent-net.rules"
-release=$(grep -P '^\ID=' /etc/os-release | tr -d 'ID=')
+release=$(grep -P '^ID=' /etc/os-release | tr -d 'ID=')
 METADATA_BASEURL="http://169.254.169.254/latest"
 METADATA_MAC_PATH="meta-data/network/interfaces/macs"
 

--- a/write_net_rules
+++ b/write_net_rules
@@ -41,7 +41,7 @@ fi
 RULES_FILE='/etc/udev/rules.d/69-c2-persistent-net.rules'
 
 # Validate os-release
-release=$(grep -P '^\ID=' /etc/os-release | tr -d 'ID=')
+release=$(grep -P '^ID=' /etc/os-release | tr -d 'ID=')
 version=$(grep -oP "VERSION_ID=.\\K[0-9]+\\.[0-9]+" /etc/os-release | tr -d ".")
 if [ ${release} = "ubuntu" ]; then
   if [ ${version} -lt 1804 ]; then


### PR DESCRIPTION
This PR fixes the problem described in https://github.com/C2Devel/c2-ec2-netutils/issues/5